### PR TITLE
Fixes *_html proposal fields

### DIFF
--- a/pinaxcon/templates/symposion/proposals/_proposal_fields.html
+++ b/pinaxcon/templates/symposion/proposals/_proposal_fields.html
@@ -29,10 +29,10 @@
     <dd>{{ proposal.description }}&nbsp;</dd>
 
     <dt>{% trans "Abstract" %}</dt>
-    <dd>{{ proposal.abstract|safe }}&nbsp;</dd>
+    <dd>{{ proposal.abstract_html|safe }}&nbsp;</dd>
 
     <dt>{% trans "Notes" %}</dt>
-    <dd>{{ proposal.additional_notes|safe }}&nbsp;</dd>
+    <dd>{{ proposal.additional_notes_html|safe }}&nbsp;</dd>
 
     <dt>{% trans "Speaker Bio" %}</dt>
     <dd>{{ proposal.speaker.biography|safe }}&nbsp;</dd>


### PR DESCRIPTION
Fixes the proposal template so that it renders the `abstract` and `additional_notes` correctly.