### PR TITLE
Add missing template file.

### DIFF
--- a/pinaxcon/templates/symposion/schedule/schedule_list.csv
+++ b/pinaxcon/templates/symposion/schedule/schedule_list.csv
@@ -1,0 +1,3 @@
+"Presentation","Speakers","Time","Room"
+{% for presentation in presentations %}"{{ presentation.title|addslashes }}","{{ presentation.speakers|join:' & '|addslashes }}","{{ presentation.slot.day.date|date:'l' }} {{ presentation.slot.start }}-{{ presentation.slot.end }}","{{ presentation.slot.rooms|join:' & '|addslashes }}"
+{% endfor %}


### PR DESCRIPTION
Add CSV template used by symposion's `schedule_list_csv` view. Without
this template, the view will return an error.
